### PR TITLE
Remove support for Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ elFinder is an open-source file manager for web, written in JavaScript using jQu
 
 ## Installation
 
-Python 3.5+ is required.
+Python 3.6+ is required.
 
 ```sh
 pip install -U imjoy-elfinder

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     description=DESCRIPTION,
     long_description=read("README.md"),
     long_description_content_type="text/markdown",
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=read("requirements.txt"),
     tests_require=read("requirements.txt") + read("requirements_test.txt"),
     classifiers=[
@@ -41,7 +41,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,8 +96,7 @@ def jpeg_file_fixture(tmp_path):
     tmp_dir = tmp_path / "sub"
     tmp_dir.mkdir(exist_ok=True)
     test_fil = tmp_dir / "test.jpeg"
-    # Python 3.5 shutil.copyfile needs strings instead of pathlib paths
-    shutil.copyfile(str(fly_img), str(test_fil))
+    shutil.copyfile(fly_img, test_fil)
     yield test_fil
 
 
@@ -108,6 +107,5 @@ def zip_file_fixture(tmp_path):
     tmp_dir = tmp_path / "sub"
     tmp_dir.mkdir(exist_ok=True)
     test_fil = tmp_dir / ZIP_FILE
-    # Python 3.5 shutil.copyfile needs strings instead of pathlib paths
-    shutil.copyfile(str(foo_zip), str(test_fil))
+    shutil.copyfile(foo_zip, test_fil)
     yield test_fil

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py35, py36, py37, py38, lint, mypy
+envlist = py36, py37, py38, lint, mypy
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-  3.5: py35, mypy
-  3.6: py36, lint
+  3.6: py36, lint, mypy
   3.7: py37
   3.8: py38
 


### PR DESCRIPTION
- Python 3.5 became end of life in 2020-09-13.