### PR TITLE
Update auto labeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,7 +1,10 @@
 autolabeler:
-  - label: "ci"
+  - label: "github_actions"
     files:
       - ".github/workflows/*"
+  - label: "ci"
+    files:
+      - ".github/*"
   - label: "documentation"
     files:
       - "*.md"

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -2,6 +2,9 @@ name: Draft release
 
 on:
   workflow_dispatch:
+  # pull_request event is required only for autolabeler
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   update-release-draft:


### PR DESCRIPTION
- Label .github/ files as ci.
- Make sure that release drafter is run on PRs to label PRs.