### PR TITLE
Remove quotes from tag version output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         uses: salsify/action-detect-and-tag-new-version@v2.0.1
         with:
           version-command: |
-            bash -o pipefail -c "cat imjoy_elfinder/VERSION | jq '.version'"
+            bash -o pipefail -c "cat imjoy_elfinder/VERSION | jq -r '.version'"
 
       - name: Build package
         run: |


### PR DESCRIPTION
- We don't want quotes around the version number when creating tag version.