### PR TITLE
Use flake8-docstrings

### DIFF
--- a/requirements_lint.txt
+++ b/requirements_lint.txt
@@ -1,4 +1,4 @@
 black==20.8b1
 flake8==3.9.1
-pydocstyle==6.0.0
+flake8-docstrings==1.6.0
 pylint==2.7.4

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,8 @@ basepython = python3
 ignore_errors = True
 commands =
   black --check ./
-  flake8 imjoy_elfinder tests
+  flake8 ./
   pylint imjoy_elfinder tests
-  pydocstyle imjoy_elfinder tests
 deps =
   -rrequirements.txt
   -rrequirements_lint.txt


### PR DESCRIPTION
- We save some time and avoid config conflicts by using the pydocstyle plugin for flake8 instead of running pydocstyle directly.