### PR TITLE
Require requests instead of starlette for tests

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,4 +2,4 @@ pytest==6.2.4
 pytest-cov==2.12.1
 pytest-timeout==1.4.2
 # tests require sub-dependencies of starlette
-starlette[full]==0.13.6
+requests==2.25.1


### PR DESCRIPTION
- The starlette test client requires requests. We don't need all of starlette.