### PR TITLE
Update jupyter-server-proxy dep for Windows fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "Framework :: FastAPI ",
         "Topic :: Internet",
     ],
-    extras_require={"jupyter": ["jupyter-server-proxy-windows"]},
+    extras_require={"jupyter": ["jupyter-server-proxy"]},
     entry_points={
         "console_scripts": ["imjoy-elfinder = imjoy_elfinder.app:main"],
         "jupyter_serverproxy_servers": [


### PR DESCRIPTION
This enables updates to the aiohttp package -- newer versions are
required for wheels on newer versions of Python.

The Windows issue has been closed: https://github.com/jupyterhub/jupyter-server-proxy/issues/147
